### PR TITLE
Bug 932103 - Air Mozilla logo too large on smaller screens

### DIFF
--- a/airmozilla/main/templates/main/_banner_small.html
+++ b/airmozilla/main/templates/main/_banner_small.html
@@ -3,7 +3,7 @@
   <a href="{{ url('main:home') }}" rel="home"
      title="{{ _('Go to the front page') }}">
     <img src="{{ static('img/logo-airmo-md.png') }}"
-         alt="{{ _('Air Mozilla') }}">
+         alt="{{ _('Air Mozilla') }}" style="width:100%;">
   </a>
 </h1>
 


### PR DESCRIPTION
On mobile devices, the Air Mozilla logo is way too big and causes a horizontal scrollbar to be shown. This can be reproduced in Firefox by opening the Responsive Design View and picking 320x480.
