### PR TITLE
 Fixed #814081 Video Templates List and menu options are ordered by name

### DIFF
--- a/airmozilla/main/models.py
+++ b/airmozilla/main/models.py
@@ -174,6 +174,9 @@ class Template(models.Model):
                   'this dictates which one is the default one.'
     )
 
+    class Meta:
+        ordering = ['name']
+
     def __unicode__(self):
         return self.name
 


### PR DESCRIPTION
Both the template dropdown menu options and the Video Template List
are alphabetically ordered.

Attempting to close https://bugzilla.mozilla.org/show_bug.cgi?id=814081. Please provide code review feedback. 
