### PR TITLE
Fixes bug 1088743 - Make clear who may sign in

### DIFF
--- a/airmozilla/comments/templates/comments/container.html
+++ b/airmozilla/comments/templates/comments/container.html
@@ -33,7 +33,7 @@
     </p>
   </form>
   {% else %}
-  <p><em>You must be signed in to post comments.</em></p>
+  <p><em><a href="https://mozillians.org/">Mozillians</a> must be signed in to post comments.</em></p>
   {% endif %}
 {% endif %}
 </div>


### PR DESCRIPTION
Make it clear user must sign in as a Mozillian not simply Persona.