### PR TITLE
Clarify location of settings/local.py-dist

### DIFF
--- a/airmozilla/settings/__init__.py
+++ b/airmozilla/settings/__init__.py
@@ -2,5 +2,5 @@ from .base import *
 try:
     from .local import *
 except ImportError, exc:
-    exc.args = tuple(['%s (did you rename settings/local.py-dist?)' % exc.args[0]])
+    exc.args = tuple(['%s (did you rename airmozilla/settings/local.py-dist?)' % exc.args[0]])
     raise exc


### PR DESCRIPTION
Even if if follows Django conventions, it's not totally obvious that `settings/local.py-dist` is in airmozilla rather than say, roku or vidlyserver.
