### PR TITLE
fix checking version for psql in devup.py

### DIFF
--- a/devup.py
+++ b/devup.py
@@ -3,6 +3,7 @@
 import os
 import sys
 import subprocess
+import re
 
 
 def _proceed(msg="Ready to proceed?"):
@@ -131,7 +132,7 @@ def check_git():
 def _get_psql_version():
     try:
         output, error = _process(['psql', '--version'])
-        return output.strip().split()[-1]
+        return re.search(r"[0-9.].*", output.strip()).group()
     except OSError:
         return None
 


### PR DESCRIPTION
Ubuntu  12.04 LTS
psql (PostgreSQL) 9.1.15
following the steps in devup.py I got next situation
![default](https://cloud.githubusercontent.com/assets/4912693/6769094/1320c74e-d096-11e4-8cda-4aad8272045a.png)
I made checking version for psql more universal
 
