### PR TITLE
fixes bug 1157938 - Hide Call info on archived events

### DIFF
--- a/airmozilla/main/forms.py
+++ b/airmozilla/main/forms.py
@@ -61,6 +61,8 @@ class EventEditForm(BaseModelForm):
         self.fields['picture'].label = (
             'Select an existing picture from the gallery'
         )
+        if not (self.event.is_upcoming() or self.event.is_live()):
+            del self.fields['call_info']
 
     def clean(self):
         cleaned_data = super(EventEditForm, self).clean()

--- a/airmozilla/main/templates/main/event.html
+++ b/airmozilla/main/templates/main/event.html
@@ -188,7 +188,7 @@
         </div>
       {% endif %}
 
-      {% if event.call_info %}
+      {% if event.call_info and (event.is_upcoming() or event.is_live()) %}
         <div class="tab">
           <input type="radio" id="tab-4" name="tab-group-1">
           <label for="tab-4">Call Info</label>


### PR DESCRIPTION
Umm, this is half complete. I decided to work on this till I figure out how to write tests. I have been having a hard time to find where is "call info" is in the event edit form. I see it calls bootstrapform(form), I went to the main/forms.py to see if it is in there but then again I can't really find its actual location to edit. It seems to be embedded at event_edit through some other file I haven't been able to locate yet; so that is one place I got stuck. Also I don't know if call info tab is to appear for pending events. Lastly what is the purpose of call info? It seems like a tag but maybe it does something special which I haven't figure that out? @peterbe 