### PR TITLE
fixes bug 1170727 - Removing Response class duplication in tests

### DIFF
--- a/airmozilla/auth/tests/test_views.py
+++ b/airmozilla/auth/tests/test_views.py
@@ -11,6 +11,7 @@ from nose.tools import ok_, eq_
 
 from airmozilla.auth.browserid_mock import mock_browserid
 from airmozilla.base import mozillians
+from airmozilla.base.tests.testbase import Response
 from airmozilla.main.models import UserProfile
 
 
@@ -85,12 +86,6 @@ NOT_VOUCHED_FOR = """
   ]
 }
 """
-
-
-class Response(object):
-    def __init__(self, content=None, status_code=200):
-        self.content = content
-        self.status_code = status_code
 
 
 class TestViews(TestCase):

--- a/airmozilla/base/tests/test_mozillians.py
+++ b/airmozilla/base/tests/test_mozillians.py
@@ -9,6 +9,7 @@ import mock
 from nose.tools import ok_, eq_
 
 from airmozilla.base import mozillians
+from airmozilla.base.tests.testbase import Response
 
 
 VOUCHED_FOR = """
@@ -244,12 +245,6 @@ assert json.loads(VOUCHED_FOR)
 assert json.loads(NOT_VOUCHED_FOR)
 assert json.loads(NO_VOUCHED_FOR)
 assert json.loads(IN_GROUPS)
-
-
-class Response(object):
-    def __init__(self, content=None, status_code=200):
-        self.content = content
-        self.status_code = status_code
 
 
 class TestMozillians(TestCase):

--- a/airmozilla/base/tests/test_utils.py
+++ b/airmozilla/base/tests/test_utils.py
@@ -7,15 +7,7 @@ from nose.tools import eq_, assert_raises
 from mock import patch
 
 from airmozilla.base import utils
-
-
-class Response(object):
-    def __init__(self, content=None, status_code=200):
-        self.content = content
-        self.status_code = status_code
-
-    def json(self):
-        return self.content
+from airmozilla.base.tests.testbase import Response
 
 
 class TestMisc(TestCase):

--- a/airmozilla/base/tests/testbase.py
+++ b/airmozilla/base/tests/testbase.py
@@ -72,3 +72,13 @@ class DjangoLiveServerTestCase(LiveServerTestCase):
         if not settings.RUN_SELENIUM_TESTS:
             raise SkipTest("settings.RUN_SELENIUM_TESTS is set to False")
         super(DjangoLiveServerTestCase, self).setUp()
+
+
+class Response(object):
+    def __init__(self, content=None, status_code=200, headers=None):
+        self.content = content
+        self.status_code = status_code
+        self.headers = headers or {}
+
+    def json(self):
+        return self.content

--- a/airmozilla/comments/tests/test_views.py
+++ b/airmozilla/comments/tests/test_views.py
@@ -14,6 +14,7 @@ from funfactory.urlresolvers import reverse
 from nose.tools import eq_, ok_
 
 from airmozilla.main.models import Event
+from airmozilla.base.tests.testbase import Response
 from airmozilla.comments.views import (
     can_manage_comments,
     get_latest_comment
@@ -60,12 +61,6 @@ MOZILLIAN_USER = """
   ]
 }
 """
-
-
-class Response(object):
-    def __init__(self, content=None, status_code=200):
-        self.content = content
-        self.status_code = status_code
 
 
 class TestComments(TestCase):

--- a/airmozilla/manage/tests/test_autocompeter.py
+++ b/airmozilla/manage/tests/test_autocompeter.py
@@ -10,19 +10,10 @@ from django.core.exceptions import ImproperlyConfigured
 
 from funfactory.urlresolvers import reverse
 
+from airmozilla.base.tests.testbase import Response
 from airmozilla.main.models import Event, EventHitStats, Approval
 from airmozilla.manage import autocompeter
 from airmozilla.base.tests.testbase import DjangoTestCase
-
-
-class Response(object):
-    def __init__(self, content, status_code=200, headers=None):
-        self.content = self.text = content
-        self.status_code = status_code
-        self.headers = headers or {}
-
-    def json(self):
-        return json.loads(self.content)
 
 
 class TestAutocompeter(DjangoTestCase):
@@ -315,7 +306,7 @@ class TestAutocompeter(DjangoTestCase):
 
         def mocked_get(url, **options):
             return Response(
-                json.dumps({'documents': 1}),
+                {'documents': 1},
                 200,
                 headers={
                     'content-type': 'application/json'
@@ -339,12 +330,12 @@ class TestAutocompeter(DjangoTestCase):
 
         def mocked_get(url, **options):
             return Response(
-                json.dumps({
+                {
                     'terms': ['foo'],
                     'results': [
                         ['/url', 'Page'],
                     ]
-                }),
+                },
                 200,
                 headers={
                     'content-type': 'application/json'

--- a/airmozilla/manage/tests/views/test_autocompeter.py
+++ b/airmozilla/manage/tests/views/test_autocompeter.py
@@ -6,7 +6,7 @@ import mock
 from funfactory.urlresolvers import reverse
 
 from .base import ManageTestCase
-from airmozilla.manage.tests.test_autocompeter import Response
+from airmozilla.base.tests.testbase import Response
 
 
 class TestAutocompeter(ManageTestCase):
@@ -39,7 +39,7 @@ class TestAutocompeter(ManageTestCase):
 
         def mocked_get(url, **options):
             return Response(
-                json.dumps({'documents': 3}),
+                {'documents': 3},
                 200,
                 headers={
                     'Content-Type': 'application/json'
@@ -59,12 +59,12 @@ class TestAutocompeter(ManageTestCase):
 
         def mocked_get(url, **options):
             return Response(
-                json.dumps({
+                {
                     'terms': [options['params']['q']],
                     'results': [
                         ['/url', 'Page'],
                     ]
-                }),
+                },
                 200,
                 headers={
                     'Content-Type': 'application/json'

--- a/airmozilla/suggest/tests/test_utils.py
+++ b/airmozilla/suggest/tests/test_utils.py
@@ -5,18 +5,13 @@ from nose.tools import eq_, ok_
 
 from mock import patch
 
+from airmozilla.base.tests.testbase import Response
 from airmozilla.suggest import utils
 
 
 _here = os.path.dirname(__file__)
 HAS_OPENGRAPH_FILE = os.path.join(_here, 'has_opengraph.html')
 NO_OPENGRAPH_FILE = os.path.join(_here, 'no_opengraph.html')
-
-
-class Response(object):
-    def __init__(self, content=None, status_code=200):
-        self.content = content
-        self.status_code = status_code
 
 
 class TestOpenGraph(TestCase):

--- a/airmozilla/suggest/tests/test_views.py
+++ b/airmozilla/suggest/tests/test_views.py
@@ -25,6 +25,7 @@ from airmozilla.main.models import (
     Tag,
     Picture
 )
+from airmozilla.base.tests.testbase import Response
 from airmozilla.uploads.models import Upload
 from airmozilla.comments.models import SuggestedDiscussion
 from airmozilla.base.tests.testbase import DjangoTestCase
@@ -37,12 +38,6 @@ PNG_FILE = os.path.join(_here, 'popcorn.png')
 class HeadResponse(object):
     def __init__(self, **headers):
         self.headers = headers
-
-
-class Response(object):
-    def __init__(self, content=None, status_code=200):
-        self.content = content
-        self.status_code = status_code
 
 
 class TestPages(DjangoTestCase):


### PR DESCRIPTION
As Peter Bengtsson advised to do on [bugzilla](https://bugzilla.mozilla.org/show_bug.cgi?id=1170727), I moved the Response class that was duplicated across multiple test classes into airmozilla.base.tests.testbase.

Response was implemented slightly differently in airmozilla/manage/tests/test_autocompleter vs the rest. The `json()` method returned `json.loads(self.content)` instead of simply `self.content` like the Response class in the other test classes did.

Therefore I subclassed Response from airmozilla.base.tests.testbase in test_autocompleter with the slightly different `json()` method and called it `JsonLoadingResponse` since it is loading the json instead of just returning the content of the response.

Please let me know if this is not the best way to do it or if there is any way it can be improved and I will happily revisit. Thank you

 