### PR TITLE
fixes bug 1193534 - correcting name of method in ConsoleTweeter

### DIFF
--- a/airmozilla/manage/tweeter.py
+++ b/airmozilla/manage/tweeter.py
@@ -172,7 +172,7 @@ class ConsoleTweeter(object):  # pragma: no cover
         from random import randint
         return {'id': str(randint(1000000, 10000000))}
 
-    def updateStatus(self, status):
+    def update_status(self, status):
         return self.update_status_with_media(None, status)
 
 


### PR DESCRIPTION
Hi @peterbe 

Spotted this while having a look at how integration with Twitter is implemented.

Bug : https://bugzilla.mozilla.org/show_bug.cgi?id=1193534

