### PR TITLE
Add a 1.25X playback rate option

### DIFF
--- a/airmozilla/main/templates/main/event.html
+++ b/airmozilla/main/templates/main/event.html
@@ -96,7 +96,7 @@
               <a class="open inactive"
                  title="Click to see playback rate options"></a>
               <span class="options"
-                data-options="[[0.5, &quot;Half the speed&quot;], [1, &quot;Normal speed&quot;], [1.5, &quot;One and a half the speed&quot;], [2, &quot;Double speed&quot;]]">
+                data-options="[[0.5, &quot;Half the speed&quot;], [1, &quot;Normal speed&quot;], [1.25, &quot;One and a quarter the speed&quot;], [1.5, &quot;One and a half the speed&quot;], [2, &quot;Double speed&quot;]]">
               </span>
               <span class="problem"></span>
             </span>


### PR DESCRIPTION
YouTube supports this playback rate, and it seems like it works
much better than 1.5X when listening to someone speak, in that at
1.5X, what they are saying starts to get hard to understand in a
lot of cases.