### PR TITLE
fixes bug 1350474 - increase font color contrast in footer license note

### DIFF
--- a/airmozilla/main/static/main/css/main.css
+++ b/airmozilla/main/static/main/css/main.css
@@ -470,7 +470,7 @@ body #cancel-comment-reply a:hover, body #cancel-comment-reply a:focus, body #ca
 #nav-primary .current-menu-item { border-color: #fed325; }
 
 /* @Footer ***/
-#site-info { background-color: #020202; color: #666; }
+#site-info { background-color: #020202; color: #757575; }
 #site-info a:link, #site-info a:visited { color: #68a7d0; }
 #site-info a:hover, #site-info a:focus, #site-info a:active { color: #82c0e8; }
 


### PR DESCRIPTION
Fixes [bug #1350474](https://bugzilla.mozilla.org/show_bug.cgi?id=1350474) - Change color of font in footer that states license agreement to a lighter color, increasing contrast and readability to meet accessibility guidelines.